### PR TITLE
Allow fetching admin name from steam

### DIFF
--- a/gflbans/internal/database/admin.py
+++ b/gflbans/internal/database/admin.py
@@ -11,7 +11,6 @@ from gflbans.internal.database.group import DGroup
 from gflbans.internal.flags import ALL_PERMISSIONS, PERMISSION_VPN_CHECK_SKIP
 from gflbans.internal.integrations.games.steam import _get_steam_user_info
 from gflbans.internal.integrations.ips import get_member_by_id_nc, ips_get_gsid_from_member_id, ips_process_avatar
-from gflbans.internal.log import logger
 
 
 class Admin:
@@ -40,25 +39,30 @@ class Admin:
         # Update if the next update time is less than the current time
         if self.__dadmin.last_updated == 0 or self.__dadmin.last_updated + 600 <= datetime.now(tz=UTC).\
                 timestamp():
-            adm_data = await get_member_by_id_nc(app, self.__dadmin.ips_user)
+
             self.__dadmin.last_updated = datetime.now(tz=UTC).timestamp()
-            self.__dadmin.name = adm_data['name']
             try:
                 steam_json = await _get_steam_user_info(app, ips_get_gsid_from_member_id(self.__ips_id))
                 av = DFile(**await ips_process_avatar(app, steam_json['avatarfull']))
+                self.__dadmin.name = steam_json['personaname']
             except:
                 av = None
-                logger.warning('No Admin Profile Picture found')
                 
             if av is not None:
                 self.__dadmin.avatar = av
 
             i_grps = []
 
-            for grp in adm_data['groups']:
-                if grp not in i_grps:
-                    i_grps.append(grp)
+            adm_data = await get_member_by_id_nc(app, self.__dadmin.ips_user)
+            if adm_data is not None:
+                if 'name' in adm_data:
+                    self.__dadmin.name = adm_data['name'] # Override steam name if one is specified in admin document
+                for grp in adm_data['groups']:
+                    if grp not in i_grps:
+                        i_grps.append(grp)
 
+            if self.__dadmin.name is None:
+                self.__dadmin.name = 'Unknown'
             self.__dadmin.groups = i_grps
 
             await self.__dadmin.commit(app.state.db[MONGO_DB])


### PR DESCRIPTION
- Priority: MongoDB admin document -> Steam Username -> 'Unknown'
- Fix exception when creating an Admin object without a matching admin MongoDB document